### PR TITLE
lita_config: make top o' the morning regex less greedy

### DIFF
--- a/lita_config.rb
+++ b/lita_config.rb
@@ -53,7 +53,7 @@ Lita.configure do |config|
   config.handlers.static_meme.mapping = {
     /^where('| i)s #{config.robot.name}[?]?$/i => "There is no #{config.robot.name}. There is only Zuul.",
     /^thank(s| ?you)\s#{config.robot.name}/i => "At your service.",
-    /top .* the mornin/i => "And the rest of the day to yourself.",
+    /\btop o? the mornin/i => "And the rest of the day to yourself.",
     /@channel/ => "Please use `@here` for group notifications instead. This is a thoughtful alternative that avoids unnecessary notifications sent to inactive users. (Repeated `@channel` usage is considered a CoC violation.)",
     /^!welcome/i => <<MSG,
 Welcome to :256:!


### PR DESCRIPTION
In its existing form, that regex would match `stop in the morning`,
which is not at all what we want.  Instead, at least require the `o`
in `of` or `o'`.