### PR TITLE
Update bot name comparison to be case insensitive

### DIFF
--- a/src/helpers/__test__/messageHelper.test.js
+++ b/src/helpers/__test__/messageHelper.test.js
@@ -102,6 +102,39 @@ describe( 'messageHelper', () => {
         afterEach( () => {
             process.env = OLD_ENV;
         } );
+
+        describe( 'processs.env.DEBUG', () => {
+            let consoleSpy = null;
+            
+            beforeEach( () => {
+                consoleSpy = jest.spyOn( console, 'debug' ).mockImplementation();
+                
+                event = {
+                    debugKey: 'debug value'
+                };
+            } );
+
+            afterEach( () => {
+                if( consoleSpy != null ) {
+                    consoleSpy.mockRestore();
+                }
+            } );
+
+            test( 'prints when true', () => {
+                process.env.DEBUG = true;
+
+                messageHelper.getMessageResponse( event );
+                expect( consoleSpy ).toHaveBeenCalledTimes( 1 );
+                expect( consoleSpy ).toHaveBeenCalledWith( `event: ${JSON.stringify( event, null, 2 )}` );
+            } );
+
+            test( 'does NOT print when false', () => {
+                process.env.DEBUG = false;
+
+                messageHelper.getMessageResponse( event );
+                expect( consoleSpy ).toHaveBeenCalledTimes( 0 );
+            } );
+        } );
         
         describe( 'where is', () => {
             test( 'lowercase', () => {

--- a/src/helpers/messageHelper.js
+++ b/src/helpers/messageHelper.js
@@ -11,6 +11,10 @@ const messageIsFromABot = function( event ) {
 };
 
 const getMessageResponse = function( event ) {
+    if( process.env.DEBUG == true ) {
+        console.debug( `event: ${JSON.stringify( event, null, 2 )}` );
+    }
+
     const message = event.text;
     let response = '';
 

--- a/src/helpers/messageHelper.js
+++ b/src/helpers/messageHelper.js
@@ -1,8 +1,10 @@
 const constants = require( './constants.js' );
 
 const messageIsFromABot = function( event ) {
+    const botName = new RegExp( process.env.ROBOT_NAME, 'i' );
+
     if ( event.type === 'message' && ( event.subtype === 'bot_message' ||
-      ( event.bot_profile !== null && event.bot_profile !== undefined && event.bot_profile.name == process.env.ROBOT_NAME ) ) ) {
+      ( event.bot_profile !== null && event.bot_profile !== undefined && event.bot_profile.name.match( botName ) != null ) ) ) {
         return true;
     }
     return false;


### PR DESCRIPTION
* Update bot name comparison to be case insensitive
* add `event` logging if `process.env.DEBUG` == `true` (boolean value, not string).

The later can be turned on and off dynamically since we can update the env vars while the bot is running.